### PR TITLE
Explicit superclasses for OpenSSL::Cipher::Cipher and OpenSSL::Digest::Digest.

### DIFF
--- a/lib/openssl/cipher.rb
+++ b/lib/openssl/cipher.rb
@@ -58,7 +58,7 @@ module OpenSSL
     end
 
     # This class is only provided for backwards compatibility.  Use OpenSSL::Cipher in the future.
-    class Cipher < Cipher
+    class Cipher < ::OpenSSL::Cipher
       # add warning
     end
   end # Cipher

--- a/lib/openssl/digest.rb
+++ b/lib/openssl/digest.rb
@@ -56,7 +56,7 @@ module OpenSSL
     # Deprecated.
     #
     # This class is only provided for backwards compatibility.
-    class Digest < Digest # :nodoc:
+    class Digest < ::OpenSSL::Digest # :nodoc:
       # Deprecated.
       #
       # See OpenSSL::Digest.new


### PR DESCRIPTION
Reapplying #2 

This closes #13 